### PR TITLE
fix: Do not update depedents when updateInternalDependencies is set to None

### DIFF
--- a/packages/apply-release-plan/src/version-package.ts
+++ b/packages/apply-release-plan/src/version-package.ts
@@ -37,67 +37,69 @@ export default function versionPackage(
 
   packageJson.version = newVersion;
 
-  for (let depType of DEPENDENCY_TYPES) {
-    let deps = packageJson[depType];
-    if (deps) {
-      for (let { name, version, type } of versionsToUpdate) {
-        let depCurrentVersion = deps[name];
-        if (
-          !depCurrentVersion ||
-          depCurrentVersion.startsWith("file:") ||
-          depCurrentVersion.startsWith("link:") ||
-          !shouldUpdateDependencyBasedOnConfig(
-            { version, type },
-            {
-              depVersionRange: depCurrentVersion,
-              depType,
-            },
-            {
-              minReleaseType: updateInternalDependencies,
-              onlyUpdatePeerDependentsWhenOutOfRange,
-            }
-          )
-        ) {
-          continue;
-        }
-        const usesWorkspaceRange = depCurrentVersion.startsWith("workspace:");
-
-        if (
-          !usesWorkspaceRange &&
-          bumpVersionsWithWorkspaceProtocolOnly === true
-        ) {
-          continue;
-        }
-
-        if (usesWorkspaceRange) {
-          const workspaceDepVersion = depCurrentVersion.replace(
-            /^workspace:/,
-            ""
-          );
+  if (updateInternalDependencies !== "none") {
+    for (let depType of DEPENDENCY_TYPES) {
+      let deps = packageJson[depType];
+      if (deps) {
+        for (let { name, version, type } of versionsToUpdate) {
+          let depCurrentVersion = deps[name];
           if (
-            workspaceDepVersion === "*" ||
-            workspaceDepVersion === "^" ||
-            workspaceDepVersion === "~"
+            !depCurrentVersion ||
+            depCurrentVersion.startsWith("file:") ||
+            depCurrentVersion.startsWith("link:") ||
+            !shouldUpdateDependencyBasedOnConfig(
+              { version, type },
+              {
+                depVersionRange: depCurrentVersion,
+                depType,
+              },
+              {
+                minReleaseType: updateInternalDependencies,
+                onlyUpdatePeerDependentsWhenOutOfRange,
+              }
+            )
           ) {
             continue;
           }
-          depCurrentVersion = workspaceDepVersion;
-        }
-        if (
-          // an empty string is the normalised version of x/X/*
-          // we don't want to change these versions because they will match
-          // any version and if someone makes the range that
-          // they probably want it to stay like that...
-          new semver.Range(depCurrentVersion).range !== "" ||
-          // ...unless the current version of a dependency is a prerelease (which doesn't satisfy x/X/*)
-          // leaving those as is would leave the package in a non-installable state (wrong dep versions would get installed)
-          semver.prerelease(version) !== null
-        ) {
-          let newNewRange = snapshot
-            ? version
-            : `${getVersionRangeType(depCurrentVersion)}${version}`;
-          if (usesWorkspaceRange) newNewRange = `workspace:${newNewRange}`;
-          deps[name] = newNewRange;
+          const usesWorkspaceRange = depCurrentVersion.startsWith("workspace:");
+
+          if (
+            !usesWorkspaceRange &&
+            bumpVersionsWithWorkspaceProtocolOnly === true
+          ) {
+            continue;
+          }
+
+          if (usesWorkspaceRange) {
+            const workspaceDepVersion = depCurrentVersion.replace(
+              /^workspace:/,
+              ""
+            );
+            if (
+              workspaceDepVersion === "*" ||
+              workspaceDepVersion === "^" ||
+              workspaceDepVersion === "~"
+            ) {
+              continue;
+            }
+            depCurrentVersion = workspaceDepVersion;
+          }
+          if (
+            // an empty string is the normalised version of x/X/*
+            // we don't want to change these versions because they will match
+            // any version and if someone makes the range that
+            // they probably want it to stay like that...
+            new semver.Range(depCurrentVersion).range !== "" ||
+            // ...unless the current version of a dependency is a prerelease (which doesn't satisfy x/X/*)
+            // leaving those as is would leave the package in a non-installable state (wrong dep versions would get installed)
+            semver.prerelease(version) !== null
+          ) {
+            let newNewRange = snapshot
+              ? version
+              : `${getVersionRangeType(depCurrentVersion)}${version}`;
+            if (usesWorkspaceRange) newNewRange = `workspace:${newNewRange}`;
+            deps[name] = newNewRange;
+          }
         }
       }
     }


### PR DESCRIPTION
When updating a package it currently automatically runs through and updates all the packages that use that package as a dependency.
This turns into an issue when that's not the desired action, such as when you update to a major version. It also causes an issue because the package can be referenced before the package is published when deploying.
When the updateInternalDependencies is set to none, this change makes sure that no internal dependencies are updated.
The versions of packages with dependecies are still updated. This is used by react native to update their compontents from a common workspace respository.

Consider:
package a package.json
```
{
  "name": "package-a",
  "version": "1.0.0"
}
```
package b packages.json
```
{
  "name": "package-b",
  "version": "3.3.3",
  "dependencies: {
     package-a: "^1.0.0"
}
```

Before this change if you submit a major change to package a, you get
package a package.json
```
{
  "name": "package-a",
  "version": "2.0.0"
}
```
package b package.json
```
{
  "name": "package-b",
  "version": "3.3.4",
  "dependencies: {
     package-a: "^2.0.0"
}
```
Package A is updated to 2.0, Package B is patched, and Package B's Package A dependency is also updated to 2.0


After this change you get:
package a package.json
```
{
  "name": "package-a",
  "version": "2.0.0"
}
```
package b package.json
```
{
  "name": "package-b",
  "version": "3.3.4",
  "dependencies: {
     package-a: "^1.0.0"
}
```
Package A is updated to 2.0, Package B is patched, and Package B's Package A dependency remains at ^1.0.0