### PR TITLE
CWC-4286: changeset version output

### DIFF
--- a/.changeset/wicked-lemons-listen.md
+++ b/.changeset/wicked-lemons-listen.md
@@ -1,5 +1,0 @@
----
-"@cosm-changesets/cli": minor
----
-
-Adding the since attribute to the add command

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/changesets/changesets.git"
+    "url": "https://github.com/cosm-public/changesets.git"
   },
   "workspaces": [
     "packages/*",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @cosm-changesets/cli
 
+## 2.27.0
+
+### Minor Changes
+
+- [`5df6cc3`](https://github.com/changesets/changesets/commit/5df6cc3248f8d16a92747e0cd7b284455209b309) Thanks [@labmorales](https://github.com/labmorales)! - Adding the since attribute to the add command
+
 ## 2.26.1
 
 ### Patch Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cosm-changesets/cli",
-  "version": "2.26.1",
+  "version": "2.27.0",
   "description": "Organise your package versioning and publishing to make both contributors and maintainers happy",
   "bin": {
     "changeset": "bin.js"


### PR DESCRIPTION
## What did you implement:
Implemented issue: [CWC-4286](https://experiencecosm.atlassian.net/browse/CWC-4286)

## How did you implement it:

Files changed by the latest cli package change generated by the `pnpm run changeset version` command.

The package was already released: https://cloudsmith.io/~cosm/repos/changesets/packages/detail/npm/@cosm-changesets%252Fcli/2.27.0/

## How can we verify it:

## Checklist
- [X] I reviewed existing Pull Requests before submitting mine.
- [ ] If a protobuf file was changed, I have created a corresponding MongoDB migration.

